### PR TITLE
feat: Adobe Audition Marker Export Support

### DIFF
--- a/src/Cue/Parser.test.ts
+++ b/src/Cue/Parser.test.ts
@@ -60,6 +60,7 @@ describe('Parser', () => {
       ' 5541.293333    7143.640000     19': '92:21:21',
       ' 50:10:01 \n': '50:10:01',
       '01 120:10.01 (Split)': '120:10:01',
+      'Marker 02\t12:30.862\t0:00.000\tdecimal\tCue\t' : '12:30:64',
     };
 
     Object.keys(regionsList).forEach((key: string) => {

--- a/src/Cue/Parser.ts
+++ b/src/Cue/Parser.ts
@@ -184,6 +184,22 @@ export default class Parser {
     for (let i = 0; i < contents.length; i++) {
       const row = contents[i].trim();
 
+      // Audition marker export
+      matches = row.match(/(\d+):(\d+)\.(\d+)\t\d+:\d+\.\d+\tdecimal\tCue/i);
+      if (null != matches) {
+        let mn = Number(matches[1]) || 0;
+        const sc = Number(matches[2]) || 0;
+        const milliseconds = Number(matches[3]) || 0;
+
+        // frames can not be more than 74, so floor them instead of round
+        const fr = Math.floor(parseFloat(0 + '.' + milliseconds) * 75);
+
+        const timeEntry = (mn < 10 ? '0' + mn : mn) + ':' + (sc < 10 ? '0' + sc : sc) + ':' + (fr < 10 ? '0' + fr : fr);
+        regionsList.push(timeEntry);
+
+        continue;
+      }
+
       // Soundforge or Audition
       matches = row.match(/(\d{2}:\d{2}:\d{2}[\.,:]\d{2})/i);
       if (null != matches) {


### PR DESCRIPTION
# feat: Adobe Audition Marker Export Support

Adobe Audition can export markers to a file with the following format.
```
Name	Start	Duration	Time Format	Type	Description
	0:18.000	0:00.000	decimal	Cue	
	0:21.000	0:00.000	decimal	Cue	
```
Each field is separated with a tab.

# BREAKING CHANGE: No
